### PR TITLE
feat: Use BaseProvider random to allow seeding from Faker

### DIFF
--- a/src/vehicle/__init__.py
+++ b/src/vehicle/__init__.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from random import choice
 from faker.providers import BaseProvider
 from .vehicle_dict import vehicles
 from .machine_dict import machinery
+
 
 class VehicleProvider(BaseProvider):
     """
@@ -20,7 +20,7 @@ class VehicleProvider(BaseProvider):
         Returns a random vehicle dict example:
         {"Year": 2008, "Make": "Jeep", "Model": "Wrangler", "Category": "SUV"}
         """
-        veh = choice(vehicles)
+        veh = self.generator.random.choice(vehicles)
         return veh
 
     def vehicle_year_make_model(self):
@@ -49,7 +49,7 @@ class VehicleProvider(BaseProvider):
         make = veh.get('Make')
         model = veh.get('Model')
         return make + ' ' + model
-    
+
     def vehicle_make_model_cat(self):
         """
         Returns Make Model Cat example:
@@ -80,18 +80,28 @@ class VehicleProvider(BaseProvider):
         """Returns Category example: SUV"""
         veh = self.vehicle_object()
         return veh.get('Category')
-    
+
+    def random_letter(self):
+        letters = list('ABCEHKMOPTXY')
+        return self.generator.random.choice(letters)
+
     def vehicle_number(self):
         """Generates random car number"""
-        letters = list('ABCEHKMOPTXY')
-        number = choice(letters) + str(randint(0, 999)).zfill(3) + choice(letters) + choice(letters)
+        number = str(self.random_number(digits=3, fix_len=3))
+        vehicle_number = (
+            self.random_letter() +
+            number +
+            self.random_letter() +
+            self.random_letter()
+        )
+        return vehicle_number
 
     def machine_object(self):
         """
         Returns a random machine dict example:
         {"Year": 2008, "Make": "Caterpillar", "Model": "5511C", "Category": "Feller Buncher"}
         """
-        machine = choice(machinery)
+        machine = self.generator.random.choice(machinery)
         return machine
 
     def machine_year_make_model(self):
@@ -120,7 +130,7 @@ class VehicleProvider(BaseProvider):
         make = machine.get('Make')
         model = machine.get('Model')
         return make + ' ' + model
-    
+
     def machine_make_model_cat(self):
         """
         Returns Make Model Cat example:

--- a/tests/test_machinery.py
+++ b/tests/test_machinery.py
@@ -6,10 +6,27 @@ def test_machinery(fake, machinery):
     assert 'Make' in v.keys()
     assert 'Model' in v.keys()
 
+
+def test_seeded_machine_object():
+    from faker import Faker
+    from src.vehicle import VehicleProvider
+
+    def get_seeded_machine_object(fake, seed=1):
+        fake.seed_instance(seed)
+        return fake.machine_object()
+
+    fake = Faker()
+    fake.add_provider(VehicleProvider)
+    models = [get_seeded_machine_object(fake) for _ in range(2)]
+
+    assert all(m == models[0] for m in models)
+
+
 def test_make(fake, machine_makes):
     make = fake.machine_make()
     assert len(make) > 1
     assert make in machine_makes
+
 
 def test_year(fake, machine_years):
     year = fake.machine_year()
@@ -22,20 +39,24 @@ def test_model(fake, machine_models):
     assert len(model) >= 1
     assert model in machine_models
 
+
 def test_category(fake, machine_categories):
     category = fake.machine_category()
     assert len(category) > 1
     assert category in machine_categories
+
 
 def test_machine_make_model(fake):
     ar_mm = fake.machine_make_model().split()
     # check to see if there are 2 words
     assert len(ar_mm) >= 1
 
+
 def test_machine_make_model_cat(fake):
     ar_ymmc = fake.machine_make_model_cat().split()
     # check to see if there are 3 words
     assert len(ar_ymmc) >= 2
+
 
 def test_machine_year_make_model(fake):
     ar_ymm = fake.machine_year_make_model().split()

--- a/tests/test_vehicle.py
+++ b/tests/test_vehicle.py
@@ -7,6 +7,21 @@ def test_vehicles(fake, vehicles):
     assert 'Model' in v.keys()
 
 
+def test_seeded_vehicle_object():
+    from faker import Faker
+    from src.vehicle import VehicleProvider
+
+    def get_seeded_vehicle_object(fake, seed=1):
+        fake.seed_instance(seed)
+        return fake.vehicle_object()
+
+    fake = Faker()
+    fake.add_provider(VehicleProvider)
+    models = [get_seeded_vehicle_object(fake) for _ in range(2)]
+
+    assert all(m == models[0] for m in models)
+
+
 def test_make(fake, makes):
     make = fake.vehicle_make()
     assert len(make) > 1
@@ -34,9 +49,9 @@ def test_category(fake, categories):
 def test_vehicle_number(fake):
     number = fake.vehicle_number()
     assert len(number) == 6
-    assert number[0].isletter()
+    assert number[0].isalpha()
     assert number[1:4].isdigit()
-    assert number[4:6].isletter()
+    assert number[4:6].isalpha()
 
 
 def test_vehicle_make_model(fake):
@@ -44,10 +59,12 @@ def test_vehicle_make_model(fake):
     # check to see if there are 2 words
     assert len(ar_mm) >= 1
 
+
 def test_vehicle_make_model_cat(fake):
     ar_ymmc = fake.vehicle_make_model_cat().split()
     # check to see if there are 3 words
     assert len(ar_ymmc) >= 2
+
 
 def test_vehicle_year_make_model(fake):
     ar_ymm = fake.vehicle_year_make_model().split()


### PR DESCRIPTION
We use this package in an undisclosed project, and noticed that despite seeding faker for snapshotting, `VehicleProvider` does not follow Faker's seeded values.

* Using BaseProvider's `generator.random` allows this to happen, rather than importing `random.choice`.
* Additionally, I've noticed that a recent addition `vehicle_number` was using an unimported `randint`, and the test was failing. These are resolved as well.
* Formatter I have set up updated some whitespacing to follow PEP8 norms.

Hope this helps anyone that's might have bumped into the same issue, and feel free to make updates if anything here is suboptimal.